### PR TITLE
Feature device info fix

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,7 @@ var nodeVersion = require('node-version');
 
 
 gulp.task('clean', function () {
-    return del('lib');
+    return del('lib/**');
 });
 
 gulp.task('lint', function () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "test": "gulp test",
+    "build": "gulp build",
     "publish-please": "publish-please",
     "prepublish": "publish-please guard"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -180,10 +180,10 @@ export default {
             
             if (deviceId.length === 0) continue; // not a device
             debug.log('[android] found device: ' + deviceId);
-            const deviceModel = (await this._shellExec(`adb -s ${deviceId} shell getprop ro.vendor.product.model`))[0];
+            const deviceModel = (await this._shellExec(`adb -s ${deviceId} shell getprop ro.product.vendor.model`))[0];
 
-            debug.log('[android] found device model: ' + deviceId);
-            
+            debug.log('[android] found device model: ' + deviceModel);
+
             for (const browser of Object.values(this._browserDefinitions)) {
                 debug.log('[android] checking for browser: ' + browser.packageName);
             


### PR DESCRIPTION
Here are changes:
- keep lib when running clean task to avoid no directory error
- create a build task for debugging
- update `ro.vendor.product.model` to `ro.product.vendor.model` to get the model info
- fix typo to print deviceModel in the log

So in my project I can run testcafe test in Android emulator by using `testcafe 'android:Android SDK built for x86:emulator-5554:chrome' tests`.

And I can see the device model in the log like

```
[android] found device: emulator-5554

[android] found device model: Android SDK built for x86
```